### PR TITLE
Move router fn to a top-level definition

### DIFF
--- a/src/babashka/http_server.clj
+++ b/src/babashka/http_server.clj
@@ -152,6 +152,23 @@
   {:headers {"Content-Type" (ext-mime-type (fs/file-name path))}
    :body (fs/file path)})
 
+(defn router-on [dir]
+  (fn [{:keys [uri]}]
+    (let [f (fs/path dir (str/replace-first (URLDecoder/decode uri) #"^/" ""))
+          index-file (fs/path f "index.html")]
+      (cond
+        (and (fs/directory? f) (fs/readable? index-file))
+        (body index-file)
+
+        (fs/directory? f)
+        (index dir f)
+
+        (fs/readable? f)
+        (body f)
+
+        :else
+        {:status 404 :body (str "Not found `" f "` in " dir)}))))
+
 (defn serve
   "Serves static assets using web server.
 Options:
@@ -167,23 +184,7 @@ Options:
     (assert (fs/directory? dir) (str "The given dir `" dir "` is not a directory."))
     (binding [*out* *err*]
       (println (str "Serving assets at http://localhost:" (:port opts))))
-    (server/run-server
-     (fn [{:keys [uri]}]
-       (let [f (fs/path dir (str/replace-first (URLDecoder/decode uri) #"^/" ""))
-             index-file (fs/path f "index.html")]
-         (cond
-           (and (fs/directory? f) (fs/readable? index-file))
-           (body index-file)
-
-           (fs/directory? f)
-           (index dir f)
-
-           (fs/readable? f)
-           (body f)
-
-           :else
-           {:status 404 :body (str "Not found `" f "` in " dir)})))
-     opts)))
+    (server/run-server (router-on dir) opts)))
 
 (def ^:private cli-opts {:coerce {:port :long}})
 

--- a/src/babashka/http_server.clj
+++ b/src/babashka/http_server.clj
@@ -152,7 +152,7 @@
   {:headers {"Content-Type" (ext-mime-type (fs/file-name path))}
    :body (fs/file path)})
 
-(defn router-on [dir]
+(defn file-router [dir]
   (fn [{:keys [uri]}]
     (let [f (fs/path dir (str/replace-first (URLDecoder/decode uri) #"^/" ""))
           index-file (fs/path f "index.html")]
@@ -184,7 +184,7 @@ Options:
     (assert (fs/directory? dir) (str "The given dir `" dir "` is not a directory."))
     (binding [*out* *err*]
       (println (str "Serving assets at http://localhost:" (:port opts))))
-    (server/run-server (router-on dir) opts)))
+    (server/run-server (file-router dir) opts)))
 
 (def ^:private cli-opts {:coerce {:port :long}})
 


### PR DESCRIPTION
Allows user to refer to the router function if they wish to extend it with middleware or other stuff, e.g. https://github.com/babashka/http-server/issues/4