### PR TITLE
Add wasm mime-type

### DIFF
--- a/src/babashka/http_server.clj
+++ b/src/babashka/http_server.clj
@@ -102,6 +102,7 @@
    "ts"       "video/mp2t"
    "ttf"      "font/ttf"
    "txt"      "text/plain"
+   "wasm"     "application/wasm"
    "webm"     "video/webm"
    "wmv"      "video/x-ms-wmv"
    "woff"     "font/woff"


### PR DESCRIPTION
Just a minor issue I noticed when trying to serve a .wasm file. I get the error:

`wasm streaming compile failed: TypeError: WebAssembly: Response has unsupported MIME type '' expected 'application/wasm'`

