### PR TITLE
Allow omitting .html in paths

### DIFF
--- a/src/babashka/http_server.clj
+++ b/src/babashka/http_server.clj
@@ -156,6 +156,9 @@
    {:headers (merge {"Content-Type" (ext-mime-type (fs/file-name path))} headers)
     :body (fs/file path)}))
 
+(defn- with-ext [path ext]
+  (fs/path (fs/parent path) (str (fs/file-name path) ext)))
+
 (defn file-router [dir headers]
   (fn [{:keys [uri]}]
     (let [f (fs/path dir (str/replace-first (URLDecoder/decode uri) #"^/" ""))
@@ -169,6 +172,9 @@
 
         (fs/readable? f)
         (body f headers)
+
+        (and (nil? (fs/extension f)) (fs/readable? (with-ext f ".html")))
+        (body (with-ext f ".html") headers)
 
         :else
         {:status 404 :body (str "Not found `" f "` in " dir)}))))


### PR DESCRIPTION
First step in my quickblog journey. I'd prefer to have the URLs in my blog stripped from the .html extension. Many web servers do this type of rewrite already, such as the one used by GitHub Pages where I'm hosting my blog. But while this works in the hosted version of my blog, I'm obviously keen to have the same links work when testing locally.

If accepted, the next step would likely be to allow the quickblog renderer to strip the extension too, if configured to do so. But first things first :)