### PR TITLE
Fix off-by-one error in range requests

### DIFF
--- a/src/babashka/http_server.clj
+++ b/src/babashka/http_server.clj
@@ -176,8 +176,9 @@
            (str/split #"-"))))
 
 (defn- read-bytes [^java.io.File f [start end]]
-  (let [end (or end (dec (min (fs/size f)
-                              (+ start (* 1024 1024)))))
+  (let [end (if end (inc end)
+              (min (fs/size f)
+                   (+ start (* 1024 1024))))
         len (- end start)
         arr (byte-array len)]
     (with-open [r (java.io.RandomAccessFile. f "r")]


### PR DESCRIPTION
Previously, http-server would send all but the last byte, causing Firefox to loop indefinitely sending the same request over and over.

I'm not sure why there was an explicit `dec` here. Maybe left over from a refactor?

Note that this case is only triggered for requests of the form `N-`, i.e. with no end cutoff. With an explicit cutoff everything worked fine.